### PR TITLE
fix: prevent ghf from navigating to home on fzf cancel

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,4 +54,6 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Workaround: explicitly specify claude executable path
+          path_to_claude_code_executable: /home/runner/.local/bin/claude
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,6 +54,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-          # Workaround: explicitly specify claude executable path
-          path_to_claude_code_executable: /home/runner/.local/bin/claude
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -63,7 +63,12 @@ alias ls='ls -G'
 {{- else }}
 alias ls='ls --color=auto'
 {{- end }}
-alias ghf='cd `ghq list -p | fzf`'
+# ghq + fzf: select repository and cd
+ghf() {
+  local dir
+  dir=$(ghq list -p | fzf) || return 0
+  [ -n "$dir" ] && cd "$dir"
+}
 
 
 # =================================================


### PR DESCRIPTION
## Summary
- `ghf`をaliasから関数に変更
- fzfをCtrl+Cでキャンセルした際、ホームディレクトリに移動しないよう修正

## Test plan
- [ ] `ghf`を実行してリポジトリを選択 → 正常に移動
- [ ] `ghf`を実行してCtrl+Cでキャンセル → 現在のディレクトリに留まる